### PR TITLE
Add check for mesh before applying texture

### DIFF
--- a/addons/uv_check/operators.py
+++ b/addons/uv_check/operators.py
@@ -20,6 +20,8 @@ def create_material(context: bpy.types.Context, material_name: str):
 
 def apply_textures(objects: List[bpy.types.Object], material_name: str):
     for obj in objects:
+        if obj.type != 'MESH':
+            continue
         if obj.active_material is None:
             obj.original_material.add().add_material(None)
         elif material_name not in obj.active_material.name:
@@ -96,6 +98,8 @@ class RemoveUVTexture(bpy.types.Operator):
 
     def execute(self, context):
         for obj in context.scene.objects:
+            if obj.type != 'MESH':
+                continue
             if len(obj.original_material) > 0:
                 if obj.original_material[0].material != obj.active_material:
                     obj.data.materials.clear()


### PR DESCRIPTION
Erro no sentry: https://sentry.io/organizations/hana3d/issues/2326388144/?project=5600656&query=is%3Aunresolved

Tenta acessar o atributo polygons de uma curve, mas ele não existe. Acho que só faz sentido aplicar o check de UV em meshes

@hana3d/dev 